### PR TITLE
Fix the "Missing JWT Token" bug in Change username/password

### DIFF
--- a/frontend/src/components/modal/ChangePasswordDialog.tsx
+++ b/frontend/src/components/modal/ChangePasswordDialog.tsx
@@ -12,6 +12,7 @@ import {
 import { Close } from '@mui/icons-material';
 import { AuthClient } from '../../utils/auth-client';
 import { useSnackbar } from '../../context/SnackbarContext';
+import { getTokens } from '../../context/UserContext';
 
 type ChangePasswordDialogProps = {
   dialogOpen: boolean;
@@ -35,6 +36,11 @@ function ChangePasswordDialog(props: ChangePasswordDialogProps) {
       return;
     }
 
+    const headers = {
+      Authorization: `Bearer ${getTokens().token}`,
+      'Content-Type': 'application/json',
+    };
+
     const body = {
       username: username.toString(),
       oldPassword: password.toString(),
@@ -42,7 +48,7 @@ function ChangePasswordDialog(props: ChangePasswordDialogProps) {
     };
 
     setLoading(true);
-    AuthClient.changePassword(body)
+    AuthClient.changePassword(headers, body)
       .then((resp) => {
         if (resp.status !== 200) throw new Error(resp.data.message);
 
@@ -112,6 +118,7 @@ function ChangePasswordDialog(props: ChangePasswordDialogProps) {
               id='newPassword'
               label='New password'
               name='newPassword'
+              type='password'
               variant='standard'
             />
           </Grid>

--- a/frontend/src/components/modal/ChangePasswordDialog.tsx
+++ b/frontend/src/components/modal/ChangePasswordDialog.tsx
@@ -12,7 +12,6 @@ import {
 import { Close } from '@mui/icons-material';
 import { AuthClient } from '../../utils/auth-client';
 import { useSnackbar } from '../../context/SnackbarContext';
-import { getTokens } from '../../context/UserContext';
 
 type ChangePasswordDialogProps = {
   dialogOpen: boolean;
@@ -36,11 +35,6 @@ function ChangePasswordDialog(props: ChangePasswordDialogProps) {
       return;
     }
 
-    const headers = {
-      Authorization: `Bearer ${getTokens().token}`,
-      'Content-Type': 'application/json',
-    };
-
     const body = {
       username: username.toString(),
       oldPassword: password.toString(),
@@ -48,7 +42,7 @@ function ChangePasswordDialog(props: ChangePasswordDialogProps) {
     };
 
     setLoading(true);
-    AuthClient.changePassword(headers, body)
+    AuthClient.changePassword(body)
       .then((resp) => {
         if (resp.status !== 200) throw new Error(resp.data.message);
 

--- a/frontend/src/components/modal/ChangeUsernameDialog.tsx
+++ b/frontend/src/components/modal/ChangeUsernameDialog.tsx
@@ -37,11 +37,6 @@ function ChangeUsernameDialog(props: ChangeUsernameDialogProps) {
       return;
     }
 
-    const headers = {
-      Authorization: `Bearer ${getTokens().token}`,
-      'Content-Type': 'application/json',
-    };
-
     const body = {
       username: username.toString(),
       password: password.toString(),
@@ -49,7 +44,7 @@ function ChangeUsernameDialog(props: ChangeUsernameDialogProps) {
     };
 
     setLoading(true);
-    AuthClient.changeUsername(headers, body)
+    AuthClient.changeUsername(body)
       .then((resp) => {
         if (resp.status !== 200) throw new Error(resp.data.message);
 

--- a/frontend/src/components/modal/ChangeUsernameDialog.tsx
+++ b/frontend/src/components/modal/ChangeUsernameDialog.tsx
@@ -37,6 +37,11 @@ function ChangeUsernameDialog(props: ChangeUsernameDialogProps) {
       return;
     }
 
+    const headers = {
+      Authorization: `Bearer ${getTokens().token}`,
+      'Content-Type': 'application/json',
+    };
+
     const body = {
       username: username.toString(),
       password: password.toString(),
@@ -44,7 +49,7 @@ function ChangeUsernameDialog(props: ChangeUsernameDialogProps) {
     };
 
     setLoading(true);
-    AuthClient.changeUsername(body)
+    AuthClient.changeUsername(headers, body)
       .then((resp) => {
         if (resp.status !== 200) throw new Error(resp.data.message);
 

--- a/frontend/src/utils/auth-client.ts
+++ b/frontend/src/utils/auth-client.ts
@@ -49,20 +49,30 @@ export const AuthClient = {
     return requests.post(URL_USER_SVC, USER_LOGOUT, body);
   },
 
-  changeUsername: (body: {
-    username: string;
-    newUsername: string;
-    password: string;
-  }): Promise<API.Response<{ message: string }>> => {
-    return requests.post(URL_USER_SVC, USER_CHANGE_USERNAME, body);
+  changeUsername: (
+    headers: { Authorization: string },
+    body: {
+      username: string;
+      newUsername: string;
+      password: string;
+    }
+  ): Promise<API.Response<{ message: string }>> => {
+    return requests.postWithHeaders(URL_USER_SVC, USER_CHANGE_USERNAME, body, {
+      headers: headers,
+    });
   },
 
-  changePassword: (body: {
-    username: string;
-    oldPassword: string;
-    newPassword: string;
-  }): Promise<API.Response<{ message: string }>> => {
-    return requests.post(URL_USER_SVC, USER_CHANGE_PASSWORD, body);
+  changePassword: (
+    headers: { Authorization: string },
+    body: {
+      username: string;
+      oldPassword: string;
+      newPassword: string;
+    }
+  ): Promise<API.Response<{ message: string }>> => {
+    return requests.postWithHeaders(URL_USER_SVC, USER_CHANGE_PASSWORD, body, {
+      headers: headers,
+    });
   },
 
   deleteUser: (data: {

--- a/frontend/src/utils/auth-client.ts
+++ b/frontend/src/utils/auth-client.ts
@@ -10,6 +10,7 @@ import {
   USER_SIGNUP,
 } from '../configs';
 import { requests, API } from './api-request';
+import { getTokens } from '../context/UserContext';
 
 export const AuthClient = {
   signUp: (body: {
@@ -49,27 +50,29 @@ export const AuthClient = {
     return requests.post(URL_USER_SVC, USER_LOGOUT, body);
   },
 
-  changeUsername: (
-    headers: { Authorization: string },
-    body: {
-      username: string;
-      newUsername: string;
-      password: string;
-    }
-  ): Promise<API.Response<{ message: string }>> => {
+  changeUsername: (body: {
+    username: string;
+    newUsername: string;
+    password: string;
+  }): Promise<API.Response<{ message: string }>> => {
+    const headers = {
+      Authorization: `Bearer ${getTokens().token}`,
+      'Content-Type': 'application/json',
+    };
     return requests.postWithHeaders(URL_USER_SVC, USER_CHANGE_USERNAME, body, {
       headers: headers,
     });
   },
 
-  changePassword: (
-    headers: { Authorization: string },
-    body: {
-      username: string;
-      oldPassword: string;
-      newPassword: string;
-    }
-  ): Promise<API.Response<{ message: string }>> => {
+  changePassword: (body: {
+    username: string;
+    oldPassword: string;
+    newPassword: string;
+  }): Promise<API.Response<{ message: string }>> => {
+    const headers = {
+      Authorization: `Bearer ${getTokens().token}`,
+      'Content-Type': 'application/json',
+    };
     return requests.postWithHeaders(URL_USER_SVC, USER_CHANGE_PASSWORD, body, {
       headers: headers,
     });


### PR DESCRIPTION
- Axios call for Change Username/Password was using `requests.post`, it should've used `requests.postWithHeader` and pass the JWT Token to the API request
- `New password` column was not set as a "password" type